### PR TITLE
Replace ifelse

### DIFF
--- a/scripts/10/m10.10t.jl
+++ b/scripts/10/m10.10t.jl
@@ -8,7 +8,7 @@ size(d) # Should be 10x5
 d[!, :log_pop] = map(x -> log(x), d[:, :population]);
 
 # New col contact_high, set binary values 1/0 if high/low contact
-d[!, :contact_high] = map(x -> ifelse(x=="high", 1, 0), d[:, :contact]);
+d.contact_high = [contact == "high" ? 1 : 0 for contact in d.contact]
 
 # This is supposed to be a "bad" model since we take non-centered data for the
 # predictor log_pop

--- a/scripts/10/m10.10t2.jl
+++ b/scripts/10/m10.10t2.jl
@@ -9,7 +9,7 @@ size(d) # Should be 10x5
 d[!, :log_pop] = map((x) -> log(x), d[:, :population]);
 
 # New col contact_high, set binary values 1/0 if high/low contact
-d[!, :contact_high] = map((x) -> ifelse(x=="high", 1, 0), d[:, :contact]);
+d.contact_high = [contact == "high" ? 1 : 0 for contact in d.contact]
 
 # New col where we center(!) the log_pop values
 mean_log_pop = mean(d[:, :log_pop]);

--- a/scripts/13/m13.2.jl
+++ b/scripts/13/m13.2.jl
@@ -8,9 +8,8 @@ delim = ";"
 d = CSV.read(data_path, DataFrame; delim)
 
 dept_map = Dict(key => idx for (idx, key) in enumerate(unique(d.dept)))
-d.male = ifelse.(d.gender .== "male", 1, 0)
+d.male = [g == "male" ? 1 : 0 for g in d.gender]
 d.dept_id = [dept_map[de] for de in d.dept]
-
 
 @model m13_2(applications, dept_id, male, admit) = begin
     sigma_dept ~ truncated(Cauchy(0, 2), 0, Inf)

--- a/scripts/13/m13.3.jl
+++ b/scripts/13/m13.3.jl
@@ -8,7 +8,7 @@ delim = ";"
 d = CSV.read(data_path, DataFrame; delim)
 
 dept_map = Dict(key => idx for (idx, key) in enumerate(unique(d.dept)))
-d.male = ifelse.(d.gender .== "male", 1, 0)
+d.male = [g == "male" ? 1 : 0 for g in d.gender]
 d.dept_id = [dept_map[de] for de in d.dept]
 
 @model m13_3(applications, dept_id, male, admit) = begin

--- a/scripts/13/m13.4.jl
+++ b/scripts/13/m13.4.jl
@@ -8,7 +8,7 @@ delim = ";"
 d = CSV.read(data_path, DataFrame; delim)
 
 dept_map = Dict(key => idx for (idx, key) in enumerate(unique(d.dept)))
-d.male = ifelse.(d.gender .== "male", 1, 0)
+d.male = [g == "male" ? 1 : 0 for g in d.gender]
 d.dept_id = [dept_map[de] for de in d.dept]
 
 @model m13_4(applications, dept_id, male, admit) = begin


### PR DESCRIPTION
When using the code, I noticed that `ifelse` is used. This function also exists in R, and for me one of the main reasons I try to avoid R. In R, it's just a hack to get stuff done because the language isn't very expressive, and because everything has to be vectorized. Luckily, we're using Julia here, so we can use clearer syntax! :smile: 

In this PR, I propose to change  all occurrences of `ifelse` with list comprehensions. 

## Example
Say, we want to replace `"a"` with 1, and `"b"` with 2 in `A`:
```
julia> A = ["a", "b", "a"]
3-element Array{String,1}:
 "a"
 "b"
 "a"
```
We could write
```
julia> map(x -> ifelse(x == "a", 1, 2), A)
3-element Array{Int64,1}:
 1
 2
 1
```
However, it is more common (and, I think, more readable) to use a ternary expression (like in C) in combination with a list comprehension
```
julia> [x == "a" ? 1 : 2 for x in A]
3-element Array{Int64,1}:
 1
 2
 1
``` 
