### PR TITLE
Simplify CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - ci
   pull_request:
 
 jobs:
@@ -13,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: 1
+          version: 1 # Latest stable release, for example, `1.5.3`.
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,51 +8,19 @@ on:
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.version == 'nightly' }}
-    strategy:
-      matrix:
-        version:
-          - '1'
-          #- nightly
-        os:
-          - ubuntu-latest
-          #- macOS-latest
-          #- windows-latest
-        arch:
-          - x86
-          - x64
-        exclude:
-          - os: windows-latest
-            arch: x86
-          - os: macOS-latest
-            arch: x86
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+          version: 1
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@v1
-        if: matrix.version == '1' && matrix.os == 'ubuntu-latest' && matrix.num_threads == 1
       - uses: codecov/codecov-action@v1
-        if: matrix.version == '1' && matrix.os == 'ubuntu-latest' && matrix.num_threads == 1
         with:
           file: lcov.info
       - uses: coverallsapp/github-action@master
-        if: matrix.version == '1' && matrix.os == 'ubuntu-latest' && matrix.num_threads == 1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: lcov.info


### PR DESCRIPTION
I was looking at the GitHub Workflow a bit and it seems that some elements are not so important for this project. This PR suggests to throw a bunch of stuff out :smile:, for the following reasons

I'll start with the most disputable change. 
### Matrix
The matrix setup for multiple systems is nice for packages like Cairo.jl or Turing.jl to ensure that their package runs on Ubuntu / Windows / Mac and on different Julia versions. For this repository, I presume that most of the complexity is in getting the models to work. I think it is very unlikely that code will be written which happens to only work on Linux. Also, most users will probably just look at the code to get the big picture, and avoiding the matrix can simplify the Workflow file a lot. So, as long as the big picture is good, that is, the model works, then it should be good. Of course, the matrix can be added back at a later point if it is necessary.

### Cache
In my experience, caches can cause quite some headaches because it can secretly contain quite some state. For example, the cache contains an old version of a package but the code assumes that a newer version is used. Also, it adds quite a few lines to the Workflow file. In this case, the cache has almost no benefit because I can't think of major artifacts being downloaded to `~/.julia/artifacts`. Most of the used packages are written in pure Julia.

I've tested the cache change. The workflow still takes about 9 minutes on my forked repository.