### PR TITLE
Fix undefined variable chns and small rewrite

### DIFF
--- a/scripts/10/m10.10t.jl
+++ b/scripts/10/m10.10t.jl
@@ -4,8 +4,7 @@ delim = ';'
 d = CSV.read(joinpath(@__DIR__, "..", "..", "data", "Kline.csv"), DataFrame; delim);
 size(d) # Should be 10x5
 
-# New col log_pop, set log() for population data
-d[!, :log_pop] = map(x -> log(x), d[:, :population]);
+d.log_pop = map(log, d.population)
 
 # New col contact_high, set binary values 1/0 if high/low contact
 d.contact_high = [contact == "high" ? 1 : 0 for contact in d.contact]
@@ -40,6 +39,6 @@ m_10_10t_result = "
 
 # Describe the draws
 
-chns |> display
+posterior |> display
 
 # End of m10.10t.jl


### PR DESCRIPTION
Fix the undefined variable `chns` and small rewrite. The model now outputs
```
Summary Statistics
  parameters      mean       std   naive_se      mcse        ess      rhat
      Symbol   Float64   Float64    Float64   Float64    Float64   Float64

           α    0.9259    0.3471     0.0110    0.0212   363.0711    1.0126
          βc   -0.0183    0.9096     0.0288    0.0526   310.3764    1.0153
          βp    0.2650    0.0336     0.0011    0.0020   375.4971    1.0131
         βpc    0.0352    0.0999     0.0032    0.0056   323.7174    1.0134

Quantiles
  parameters      2.5%     25.0%     50.0%     75.0%     97.5%
      Symbol   Float64   Float64   Float64   Float64   Float64

           α    0.1969    0.6955    0.9340    1.1554    1.6010
          βc   -1.7171   -0.6067   -0.0234    0.5835    1.7592
          βp    0.1995    0.2426    0.2640    0.2880    0.3322
         βpc   -0.1575   -0.0297    0.0344    0.1016    0.2260
```
which seems fairly similar to the bit in the comments