### PR TITLE
Change m13.7 to NUTS(0.65)

### DIFF
--- a/scripts/13/m13.7.jl
+++ b/scripts/13/m13.7.jl
@@ -36,7 +36,7 @@ end
 
 chns = sample(
     m13_7(Dmat, d.society, d.logpop, d.total_tools),
-    Turing.NUTS(0.95),
+    Turing.NUTS(0.65),
     5000
 )
 
@@ -64,5 +64,3 @@ Inference for Stan model: 6422d8042e9cdd08dae2420ad26842f1.
     rhosq   1.52    0.09 11.82   0.03   0.16   0.39   0.96   7.96 15955    1
     lp__  925.98    0.03  2.96 919.16 924.20 926.34 928.14 930.67  7296    1    
 """
-
-# End of m13.7.jl


### PR DESCRIPTION
In response to https://github.com/StatisticalRethinkingJulia/TuringModels.jl/issues/42, for m13.7, the NUTS sampler works better as NUTS(0.65) because the effective sample size is higher. 

Output on NUTS(0.95)
```
Summary Statistics
  parameters      mean       std   naive_se      mcse         ess      rhat
      Symbol   Float64   Float64    Float64   Float64     Float64   Float64

           a    1.3251    1.2191     0.0172    0.0677    285.9096    1.0027
          bp    0.2473    0.1182     0.0017    0.0042    911.0640    1.0017
       etasq    0.3713    0.8135     0.0115    0.0559    225.9016    1.0047
        g[1]   -0.3033    0.5156     0.0073    0.0421    139.5576    1.0031
        g[2]   -0.1511    0.5027     0.0071    0.0420    138.6363    1.0026
        g[3]   -0.1963    0.4883     0.0069    0.0412    138.1092    1.0021
        g[4]    0.2663    0.4516     0.0064    0.0380    142.4096    1.0022
        g[5]   -0.0051    0.4427     0.0063    0.0375    141.7021    1.0017
        g[6]   -0.4832    0.4510     0.0064    0.0375    147.5890    1.0015
        g[7]    0.0622    0.4411     0.0062    0.0364    151.7326    1.0016
        g[8]   -0.2909    0.4419     0.0062    0.0367    149.9415    1.0012
        g[9]    0.2042    0.4277     0.0060    0.0348    155.9834    1.0010
       g[10]   -0.1543    0.5292     0.0075    0.0296    325.4825    0.9998
       rhosq    1.4499    6.9762     0.0987    0.1572   2026.9409    1.0017
```
and, output on NUTS(0.65)
```
Summary Statistics
  parameters      mean       std   naive_se      mcse         ess      rhat
      Symbol   Float64   Float64    Float64   Float64     Float64   Float64

           a    1.2739    1.1451     0.0162    0.0406    809.0320    1.0000
          bp    0.2468    0.1148     0.0016    0.0037    962.4411    1.0000
       etasq    0.3212    0.3937     0.0056    0.0117   1280.4670    1.0016
        g[1]   -0.2444    0.4067     0.0058    0.0150    661.6162    1.0003
        g[2]   -0.0967    0.3932     0.0056    0.0157    594.1228    1.0000
        g[3]   -0.1440    0.3761     0.0053    0.0150    593.7547    0.9998
        g[4]    0.3212    0.3329     0.0047    0.0136    607.7597    0.9998
        g[5]    0.0532    0.3285     0.0046    0.0131    609.1391    1.0002
        g[6]   -0.4346    0.3349     0.0047    0.0120    672.7538    0.9999
        g[7]    0.1179    0.3239     0.0046    0.0131    657.4213    0.9998
        g[8]   -0.2378    0.3227     0.0046    0.0125    663.1502    0.9998
        g[9]    0.2554    0.3063     0.0043    0.0122    652.9160    0.9998
       g[10]   -0.0988    0.4330     0.0061    0.0134   1040.0763    0.9999
       rhosq    2.2386   21.7380     0.3074    0.7956    726.0831    1.0011
```
The meaning of **ess** (Effective Sample Size) is described by Kai Xu in *Probabilistic Programming in Julia* (https://www.mlmi.eng.cam.ac.uk/files/kai_xu_8224821_assignsubmission_file_xu_kai_dissertation.pdf) on page 30. There, he states that a larger value means a higher sampling efficiency. With NUTS(0.65), the  **mcse** (Monte Carlo Standard Error) also decreases, which means that NUTS(0.65) has a bettter sampling performance.