### PR TITLE
Add africa-first-candidate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ franklin.pub
 node_modules/
 package.json
 package-lock.json
+_rss/

--- a/Project.toml
+++ b/Project.toml
@@ -5,9 +5,11 @@ version = "2.0.1"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Franklin = "713c75ef-9fc9-4b05-94a9-213340da978e"
+Gadfly = "c91e804a-d5a3-530f-b6f0-dfbca275c004"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NodeJS = "2bd173c7-0d6d-553b-b6af-13a54713934c"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -20,9 +22,11 @@ Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 
 [compat]
 CSV = "0.8"
+CategoricalArrays = "0.9"
 DataFrames = "0.22"
 Distributions = "0.24"
 Franklin = "0.10"
+Gadfly = "1.3"
 NodeJS = "1.1"
 RData = "0.8"
 StatsFuns = "0.9"

--- a/_css/franklin.css
+++ b/_css/franklin.css
@@ -124,21 +124,48 @@ h6 {
 .franklin-content h6 a:hover { text-decoration: none; }
 
 .franklin-content table {
-  margin-left: auto;
-  margin-right: auto;
-  border-collapse: collapse;
-  text-align: center;
+  margin-top:1.5em;
+  margin-left:auto;
+  margin-right:auto;
+  border-collapse:collapse;
+  text-align:center
+}
+
+.franklin-content th, td {
+    font-size: 14px;
+    padding: 10px;
+}
+
+.franklin-content th, td, tr {
+  border-left: none !important;
+  border-right: none !important;
+}
+
+tr:first-of-type {
+  /* background: #eae9f4; */
+  border-top: 2px solid rgba(0, 0, 0, 0.2);
+  border-right: none;
+}
+
+tr:last-of-type {
+  border-bottom: 2px solid rgba(0, 0, 0, 0.2);
+}
+
+tr:first-of-type>th {
+ text-align:center
+}
+tr,
+th,
+td {
+ padding: 8px;
+ border: 1px solid lightgray;
+}
+table tbody tr td {
+ border:1px solid lightgray
 }
 
 .franklin-toc ol ol {
   list-style-type: lower-alpha;
-}
-
-.franklin-content th,
-td {
-  font-size: var(--small);
-  padding: 10px;
-  border: 1px solid black;
 }
 
 .franklin-content blockquote {
@@ -186,13 +213,6 @@ td {
   margin-bottom: 10px;
 }
 
-.franklin-content .fndef tr,
-td {
-  padding: 0;
-  border: 0;
-  text-align: left;
-}
-
 .franklin-content .fndef tr {
   border-left: 2px solid lightgray;
 }
@@ -210,9 +230,8 @@ td {
 }
 
 .franklin-content img {
-  width: 70%;
+  width: 100%;
   text-align: center;
-  padding-left: 10%;
 }
 
 .franklin-content .img-small img {

--- a/index.md
+++ b/index.md
@@ -50,7 +50,7 @@ Before you look at the models below, you might want to look at the [Basic Exampl
 
 - [globe.qa](models/globe-tossing): Globe tossing
 - [m4.1](models/height): Gaussian model of height
-- [m8.1](models/africa): Africa
+- [m8.1](models/africa-first-candidate): Africa first candidate model
 - [m12.1](models/beta-binomial): Beta-binomial
 - [m13.1](models/varying-intercepts-reedfrogs): Varying intercepts Reedfrogs
 - [m13.1](models/varying-slopes-cafe): Varying slopes cafes

--- a/models/africa-first-candidate.md
+++ b/models/africa-first-candidate.md
@@ -1,0 +1,41 @@
++++
+title = "Africa first candidate model"
+showall = true
++++
+
+In Edition 2 on page 244, McElreath defines the model as
+
+$$
+  \begin{aligned}
+    \log(y_i) &\sim \text{Normal}(\mu_i, \sigma) \\
+    \mu_i &= \alpha + \beta(r_i - \overline{r}) \\
+    \alpha &\sim \text{Normal}(1, 1) \\
+    \beta &\sim \text{Normal}(0, 1)
+  \end{aligned}
+$$
+
+To define this in Turing.jl, we change it to
+
+$$
+  \begin{aligned}
+    \sigma &\sim \text{Exponential(1)} \\
+    \alpha &\sim \text{Normal}(1, 0.1) \\
+    \beta &\sim \text{Normal}(0, 0.3) \\
+    \mu_i &= \alpha + \beta(r_i - \overline{r}) \\
+    y_i &\sim \text{LogitNormal}(\mu_i, \sigma)
+  \end{aligned}
+$$
+
+where $y_i$ is the GDPs for nation $i$, $r_i$ is terrain ruggedness for nation $i$ and $\overline{r}$ is the mean of the ruggedness in the whole sample.
+
+\literate{/scripts/africa-first-candidate.jl}
+
+## Original output
+
+From page 245:
+
+ | mean | sd | 5.5% | 94.5%
+--- | --- | --- | --- | ---
+α | 1.00 | 0.01 | 0.98 | 1.02
+β | 0.00 | 0.05 | -0.09 | 0.09
+σ | 0.14 | 0.01 | 0.12 | 0.15

--- a/models/height.md
+++ b/models/height.md
@@ -16,7 +16,7 @@ $$
   \end{aligned}
 $$
 
-\toc 
+\toc
 
 \literate{/scripts/height.jl}
 

--- a/scripts/africa-first-candidate.jl
+++ b/scripts/africa-first-candidate.jl
@@ -1,0 +1,41 @@
+# ## Data
+
+using DataFrames
+using Turing
+using TuringModels
+
+import CSV
+
+data_path = joinpath(TuringModels.project_root, "data", "rugged.csv")
+df = CSV.read(data_path, DataFrame)
+
+df.log_gdp = log.(df.rgdppc_2000)
+dropmissing!(df)
+
+df = select(df, :log_gdp, :rugged, :cont_africa);
+
+df.log_gdp_std = df.log_gdp ./ mean(df.log_gdp)
+df.rugged_std = df.rugged ./ maximum(df.rugged)
+
+first(df, 8)
+
+# ## Model
+
+@model function model_fn(log_gdp_std, rugged_std, mean_rugged)
+    α ~ Normal(1, 0.1)
+    β ~ Normal(0, 0.3)
+    σ ~ truncated(Exponential(1), 0, Inf)
+
+    μ = α .+ β*(rugged_std .- mean_rugged)
+    log_gdp_std .~ Normal.(μ, σ)
+end
+
+model = model_fn(df.log_gdp, df.rugged_std, mean(df.rugged));
+
+# ## Output
+
+chns = sample(model, NUTS(0.65), MCMCThreads(), 1000, 3)
+
+# \defaultgadflyoutput{}
+
+# 

--- a/scripts/africa.jl
+++ b/scripts/africa.jl
@@ -1,4 +1,5 @@
 # This is the first Stan model in Statistical Rethinking Edition 1 (page 249).
+# In Edition 2 (page 242)
 
 # \toc
 
@@ -14,10 +15,7 @@ data_path = joinpath(TuringModels.project_root, "data", "rugged.csv")
 df = CSV.read(data_path, DataFrame)
 
 df.log_gdp = log.(df.rgdppc_2000)
-
-## TODO: "Replace by dropmissing or something similar."
-notisnan(e) = !ismissing(e)
-df = df[map(notisnan, df[:, :rgdppc_2000]), :]
+dropmissing!(df)
 
 df = select(df, :log_gdp, :rugged, :cont_africa);
 

--- a/src/TuringModels.jl
+++ b/src/TuringModels.jl
@@ -1,5 +1,30 @@
 module TuringModels
 
+using CategoricalArrays
+using DataFrames
+using Gadfly
+
 const project_root = pkgdir(TuringModels)
+
+function gadfly_plot(chns)
+
+    df = DataFrame(chns)
+    params = names(chns, :parameters)
+    sdf = DataFrames.stack(df, params, variable_name=:parameter)
+    sdf[!, :chain] = categorical(sdf.chain)
+
+    p1 = plot(sdf, ygroup=:parameter, x=:iteration, y=:value, color=:chain,
+        Geom.subplot_grid(Geom.line, free_x_axis=true, free_y_axis=true),
+        Guide.ylabel("sample value"),
+        # Key is also shown on the right plot.
+        Theme(key_position=:none)
+    )
+    p2 = plot(sdf, ygroup=:parameter, x=:value, color=:chain,
+        Geom.subplot_grid(Geom.density, free_x_axis=true, free_y_axis=true,
+            Guide.xlabel(orientation=:horizontal)),
+        Guide.ylabel("density"))
+
+    hstack(p1, p2)
+end
 
 end # module

--- a/utils.jl
+++ b/utils.jl
@@ -19,8 +19,8 @@ function lx_defaultoutput(com, _)
     raw"""
     ```julia:write_helper
     # hideall
-    output_dir = @OUTPUT 
-    function write_svg(name, p) 
+    output_dir = @OUTPUT
+    function write_svg(name, p)
       fig_path = joinpath(output_dir, "$name.svg")
       StatsPlots.savefig(fig_path)
     end;
@@ -33,6 +33,46 @@ function lx_defaultoutput(com, _)
     write_svg("chns", # hide
     StatsPlots.plot(chns)
     ) # hide
+    ```
+    \output{plot}
+    \fig{chns.svg}
+    """
+end
+
+"""
+    \\defaultgadflyoutput{}
+
+Plot `chns` via Gadfly.
+Don't combine this with a call to StatsPlots or `\\defaultoutput` to avoid conflict errors.
+"""
+function lx_defaultgadflyoutput(com, _)
+    raw"""
+    ```julia:write_helper
+    # hideall
+    using DataFrames
+    using Gadfly
+    using TuringModels
+
+    output_dir = @OUTPUT
+    function write_svg(name, p, width, height)
+      fig_path = joinpath(output_dir, "$name.svg")
+      draw(SVG(fig_path, width, height), p)
+    end;
+
+    df = DataFrame(chns)
+    params = names(chns, :parameters)
+    width = 8inch
+    height = length(params) * 2inch
+    nothing
+    ```
+    \output{write_helper}
+
+    ```julia:plot
+
+    write_svg("chns", # hide
+    TuringModels.gadfly_plot(chns)
+    , width, height) # hide
+    nothing # hide
     ```
     \output{plot}
     \fig{chns.svg}


### PR DESCRIPTION
Changes:

- Fix m8.1 for edition 2. The previous africa model didn't actually correspond to the book. 
- Uses Gadfly for plotting of the new model, which works around https://github.com/TuringLang/MCMCChains.jl/issues/281.
- Fix the styling of tables, the previous CSS was quite poor; now it looks more like Pluto.jl.